### PR TITLE
Use tree-sitter for PHP parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,12 +70,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +92,15 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -137,7 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -161,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,12 +189,6 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -284,6 +296,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "httparse"
@@ -399,6 +417,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.4",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,38 +510,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "logos"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
-dependencies = [
- "beef",
- "fnv",
- "proc-macro2",
- "quote",
- "regex-syntax",
- "syn",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
-dependencies = [
- "logos-codegen",
-]
 
 [[package]]
 name = "lsp-types"
@@ -634,11 +630,12 @@ name = "phppp"
 version = "0.1.0"
 dependencies = [
  "bumpalo",
- "logos",
  "notify",
  "rayon",
  "tokio",
  "tower-lsp",
+ "tree-sitter",
+ "tree-sitter-php",
 ]
 
 [[package]]
@@ -730,10 +727,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.29"
+name = "regex"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -788,6 +808,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -804,6 +825,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -844,6 +871,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"
@@ -1008,6 +1041,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ tokio = { version = "1", features = ["full"] }
 notify = "6"
 rayon = "1"
 bumpalo = "3"
-logos = "0.13"
+tree-sitter = "0.25"
+tree-sitter-php = "0.23"

--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -10,6 +10,6 @@ fn main() {
     let bump = Bump::new();
     let ast = parser::parse_php(&text, &bump);
     let symbols = indexer::extract_symbols(&ast);
-    println!("Tokens: {:?}", ast.0);
+    println!("AST: {}", ast.0.root_node().to_sexp());
     println!("Symbols: {:?}", symbols);
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,4 +1,4 @@
-use crate::parser::Token;
+use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
 pub struct Symbol {
@@ -6,13 +6,20 @@ pub struct Symbol {
 }
 
 pub fn extract_symbols(ast: &crate::parser::Ast) -> Vec<Symbol> {
-    ast.0
-        .iter()
-        .filter_map(|tok| match tok {
-            Token::Ident => Some(Symbol {
-                name: "identifier".to_string(),
-            }),
-            _ => None,
-        })
-        .collect()
+    let mut result = Vec::new();
+    collect_names(ast.0.root_node(), &mut result);
+    result
+}
+
+fn collect_names(node: Node, out: &mut Vec<Symbol>) {
+    if node.kind() == "name" {
+        out.push(Symbol {
+            name: "identifier".to_string(),
+        });
+    }
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            collect_names(child, out);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, LspService, Server};
 
-use phppp::{analyzer, fs, indexer, parser};
+use phppp::{analyzer, indexer, parser};
 
 #[derive(Default)]
 struct DocumentState {
@@ -69,7 +69,7 @@ impl Backend {
     async fn handle_change(&self, uri: Url, content: String) {
         let mut docs = self.documents.lock().unwrap();
         let bump = self.bump.lock().unwrap();
-        let ast = parser::parse_php(&content, &bump); // fast, zero-copy
+        let ast = parser::parse_php(&content, &bump); // parsed with tree-sitter
         let symbols = indexer::extract_symbols(&ast);
 
         analyzer::resolve_types_parallel(&symbols);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,28 +1,15 @@
 use bumpalo::Bump;
-use logos::Logos;
-
-#[derive(Debug, Logos, PartialEq)]
-pub enum Token {
-    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*")]
-    Ident,
-
-    #[regex(r"[0-9]+")]
-    Number,
-
-    #[token("<?php")]
-    PhpStart,
-
-    #[token("?>")]
-    PhpEnd,
-
-    #[regex(r"\s+", logos::skip)]
-    Whitespace,
-}
+use tree_sitter::{Parser, Tree};
+use tree_sitter_php::LANGUAGE_PHP;
 
 #[derive(Debug)]
-pub struct Ast(pub Vec<Token>);
+pub struct Ast(pub Tree);
 
 pub fn parse_php(input: &str, _bump: &Bump) -> Ast {
-    let lexer = Token::lexer(input);
-    Ast(lexer.filter_map(Result::ok).collect())
+    let mut parser = Parser::new();
+    parser
+        .set_language(&LANGUAGE_PHP.into())
+        .expect("Failed to load PHP grammar");
+    let tree = parser.parse(input, None).expect("Failed to parse");
+    Ast(tree)
 }


### PR DESCRIPTION
## Summary
- use tree-sitter and the tree-sitter-php grammar
- update parser implementation and indexer traversal
- print AST in example binary
- keep LSP server building with new parser

## Testing
- `cargo fmt --all`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684cf25b16a48332ac73150525a4f6ea