### PR TITLE
Add specific example tests

### DIFF
--- a/examples/calculator.php
+++ b/examples/calculator.php
@@ -1,0 +1,22 @@
+<?php
+namespace App;
+
+function add($a, $b) {
+    return $a + $b;
+}
+
+const PI = 3.14159;
+
+class Circle {
+    public $radius;
+    public function __construct($r) {
+        $this->radius = $r;
+    }
+    public function area() {
+        return PI * $this->radius * $this->radius;
+    }
+}
+
+$circle = new Circle(5);
+echo add(2, 3);
+?>

--- a/examples/user.php
+++ b/examples/user.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Models;
+
+class User {
+    private $name;
+    public function __construct($name) {
+        $this->name = $name;
+    }
+    public function getName() {
+        return $this->name;
+    }
+}
+
+function create_user($name) {
+    return new User($name);
+}
+
+$john = create_user('John');
+echo $john->getName();
+?>

--- a/tests/example_calculator.rs
+++ b/tests/example_calculator.rs
@@ -1,0 +1,35 @@
+use bumpalo::Bump;
+use std::{fs, process::Command};
+use tower_lsp::lsp_types::Url;
+
+use phppp::{indexer, parser};
+
+#[test]
+fn calculator_example() {
+    let path = fs::canonicalize("examples/calculator.php").unwrap();
+    let text = fs::read_to_string(&path).unwrap();
+    let bump = Bump::new();
+    let ast = parser::parse_php(&text, &bump);
+    assert!(!ast.0.root_node().has_error(), "Parse error");
+
+    let uri = Url::from_file_path(&path).unwrap();
+    let symbols = indexer::extract_symbols(&text, &ast, &uri);
+    assert!(symbols.contains_key("App\\add"), "function add not indexed");
+    assert!(
+        symbols.contains_key("App\\Circle"),
+        "class Circle not indexed"
+    );
+    assert!(symbols.contains_key("App\\PI"), "constant PI not indexed");
+    assert!(
+        symbols.contains_key("App\\$circle"),
+        "variable $circle not indexed"
+    );
+
+    let output = Command::new("php")
+        .arg(&path)
+        .output()
+        .expect("failed to run php");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "5");
+}

--- a/tests/example_hello.rs
+++ b/tests/example_hello.rs
@@ -1,0 +1,26 @@
+use bumpalo::Bump;
+use std::{fs, process::Command};
+use tower_lsp::lsp_types::Url;
+
+use phppp::{indexer, parser};
+
+#[test]
+fn hello_example() {
+    let path = fs::canonicalize("examples/hello.php").unwrap();
+    let text = fs::read_to_string(&path).unwrap();
+    let bump = Bump::new();
+    let ast = parser::parse_php(&text, &bump);
+    assert!(!ast.0.root_node().has_error(), "Parse error");
+
+    let uri = Url::from_file_path(&path).unwrap();
+    let symbols = indexer::extract_symbols(&text, &ast, &uri);
+    assert!(symbols.contains_key("greet"), "function greet not indexed");
+
+    let output = Command::new("php")
+        .arg(&path)
+        .output()
+        .expect("failed to run php");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "Hello, World!");
+}

--- a/tests/example_user.rs
+++ b/tests/example_user.rs
@@ -1,0 +1,37 @@
+use bumpalo::Bump;
+use std::{fs, process::Command};
+use tower_lsp::lsp_types::Url;
+
+use phppp::{indexer, parser};
+
+#[test]
+fn user_example() {
+    let path = fs::canonicalize("examples/user.php").unwrap();
+    let text = fs::read_to_string(&path).unwrap();
+    let bump = Bump::new();
+    let ast = parser::parse_php(&text, &bump);
+    assert!(!ast.0.root_node().has_error(), "Parse error");
+
+    let uri = Url::from_file_path(&path).unwrap();
+    let symbols = indexer::extract_symbols(&text, &ast, &uri);
+    assert!(
+        symbols.contains_key("App\\Models\\create_user"),
+        "function create_user not indexed"
+    );
+    assert!(
+        symbols.contains_key("App\\Models\\User"),
+        "class User not indexed"
+    );
+    assert!(
+        symbols.contains_key("App\\Models\\$john"),
+        "variable $john not indexed"
+    );
+
+    let output = Command::new("php")
+        .arg(&path)
+        .output()
+        .expect("failed to run php");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "John");
+}


### PR DESCRIPTION
## Summary
- split example tests by file to check parsed symbols
- verify symbol names and runtime output for each PHP example

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d02f2eed0833283134f9a1946c046