### PR TITLE
Add restart command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - Follow best practices for Rust code, project structure, documentation, logging, monitoring, etc.
 - Follow best practices to implement the LSP server.
 - Make sure the code work correctly with all php files in `examples/` folder.
+- Bump the `version` field in `Cargo.toml` whenever new functionality is added.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phppp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bumpalo",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phppp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [lib]

--- a/runlsp.sh
+++ b/runlsp.sh
@@ -30,12 +30,15 @@ cat > "$EXT_DIR/package.json" <<EOF
   "name": "$LSP_NAME",
   "displayName": "PHP LSP (phppp)",
   "description": "Rust-based PHP Language Server Protocol implementation",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "local-dev",
   "main": "./extension.js",
   "engines": { "vscode": "^1.80.0" },
   "categories": ["Programming Languages", "Language Packs"],
-  "activationEvents": ["onLanguage:php"],
+  "activationEvents": [
+    "onLanguage:php",
+    "onCommand:phppp.restart"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/thethongngu/phppp"
@@ -43,10 +46,14 @@ cat > "$EXT_DIR/package.json" <<EOF
   "license": "MIT",
   "keywords": ["php", "lsp", "language server", "phppp"],
   "contributes": {
-    "languages": [{ 
-      "id": "php", 
+    "languages": [{
+      "id": "php",
       "extensions": [".php"],
       "aliases": ["PHP", "php"]
+    }],
+    "commands": [{
+      "command": "phppp.restart",
+      "title": "phppp: Restart Server"
     }]
   },
   "devDependencies": {
@@ -92,6 +99,13 @@ function activate(context) {
         fileEvents: vscode.workspace.createFileSystemWatcher("**/*.php")
       }
     }
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("phppp.restart", async () => {
+      await client.stop();
+      client.start();
+    })
   );
 
   context.subscriptions.push(client.start());

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,6 +25,7 @@ pub struct Backend {
 impl Backend {
     pub fn new(client: Client) -> Self {
         crate::logging::init(client.clone());
+        log::info!("running phppp version {}", env!("CARGO_PKG_VERSION"));
         Self {
             client,
             documents: Arc::new(Mutex::new(HashMap::new())),
@@ -100,6 +101,7 @@ impl LanguageServer for Backend {
                         resolved.name,
                         resolved.location
                     );
+                    log::debug!("goto_definition: returning definition");
                     return Ok(Some(GotoDefinitionResponse::Scalar(resolved.location)));
                 } else {
                     log::debug!("goto_definition: symbol '{}' not resolved", name);
@@ -114,6 +116,7 @@ impl LanguageServer for Backend {
             log::debug!("goto_definition: document not found for uri {}", uri);
         }
         log::debug!("goto_definition: returning None");
+        log::debug!("goto_definition completed");
         Ok(None)
     }
 
@@ -140,6 +143,7 @@ impl LanguageServer for Backend {
             }
         }
         log::debug!("completion returned {} items", items.len());
+        log::debug!("completion completed");
         Ok(Some(CompletionResponse::Array(items)))
     }
 
@@ -162,6 +166,7 @@ impl LanguageServer for Backend {
                         "{} {:?}",
                         resolved.name, resolved.kind
                     )));
+                    log::debug!("hover: returning information for {}", resolved.name);
                     return Ok(Some(Hover {
                         contents,
                         range: Some(resolved.location.range),
@@ -169,6 +174,7 @@ impl LanguageServer for Backend {
                 }
             }
         }
+        log::debug!("hover: returning None");
         Ok(None)
     }
 


### PR DESCRIPTION
## Summary
- expose `phppp.restart` command via the VSCode extension
- log the running version on server startup
- add debug statements for LSP handlers
- bump package versions
- document version bump policy

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684d3e5c463883328d888f2a43187040