### PR TITLE
Implement milestone 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phppp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bumpalo",
  "dashmap",
@@ -666,6 +666,7 @@ dependencies = [
  "tower-lsp",
  "tree-sitter",
  "tree-sitter-php",
+ "walkdir",
  "which",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phppp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [lib]
@@ -31,3 +31,4 @@ log = "0.4.27"
 once_cell = "1"
 serde_json = "1"
 which = "5"
+walkdir = "2"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,9 +29,9 @@ Enhance developer productivity with advanced analysis and refactoring tools.
 - Incremental diagnostics with real-time feedback
 
 ### TODO
-- [ ] Implement indexer module for workspace scanning
-- [ ] Add integration tests for rename and references
-- [ ] Support incremental file watching via `notify` crate
+- [x] Implement indexer module for workspace scanning
+- [x] Add integration tests for rename and references
+- [x] Support incremental file watching via `notify` crate
 - [ ] Profile and optimize analyzer performance
 
 ## Milestone 3: Ecosystem Integration

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -24,7 +24,7 @@ aliasFunc();
     let uri_b = Url::parse("file:///b.php").unwrap();
     let symbols_b = indexer::extract_symbols(src_b, &ast_b, &uri_b);
 
-    let index = indexer::GlobalIndex::new();
+    let index = indexer::new_index();
     index.insert(uri_a.clone(), symbols_a.clone());
     index.insert(uri_b.clone(), symbols_b.clone());
     let pos = Position {
@@ -50,7 +50,7 @@ function foo($bar) {
     let ast = parser::parse_php(src, &bump);
     let uri = Url::parse("file:///c.php").unwrap();
     let symbols = indexer::extract_symbols(src, &ast, &uri);
-    let index = indexer::GlobalIndex::new();
+    let index = indexer::new_index();
     index.insert(uri.clone(), symbols.clone());
 
     let pos = Position {


### PR DESCRIPTION
## Summary
- add workspace scanning with indexer and file watcher
- implement references and rename LSP handlers
- include new integration tests
- bump version and mark roadmap progress

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68591d1645e8833293bb16bdbc4adfce